### PR TITLE
Enable E226 linting and fix all E226 errors

### DIFF
--- a/botogram/api.py
+++ b/botogram/api.py
@@ -36,7 +36,7 @@ class TelegramAPI:
 
     def call(self, method, params=None, files=None, expect=None):
         """Call a method of the API"""
-        url = self._endpoint+"bot%s/%s" % (self._api_key, method)
+        url = self._endpoint + "bot%s/%s" % (self._api_key, method)
         response = requests.get(url, params=params, files=files)
         content = response.json()
 
@@ -55,7 +55,7 @@ class TelegramAPI:
 
     def file_content(self, path):
         """Get the content of an user-submitted file"""
-        url = self._endpoint+"file/bot%s/%s" % (self._api_key, path)
+        url = self._endpoint + "file/bot%s/%s" % (self._api_key, path)
         response = requests.get(url)
 
         return response.content

--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -83,7 +83,7 @@ class Bot(frozenbot.FrozenBot):
 
         # This regex will match all commands pointed to this bot
         self._commands_re = re.compile(r'^\/([a-zA-Z0-9_]+)(@' +
-                                       self.itself.username+r')?( .*)?$')
+                                       self.itself.username + r')?( .*)?$')
 
     def __reduce__(self):
         # Use the standard __reduce__

--- a/botogram/components.py
+++ b/botogram/components.py
@@ -166,7 +166,7 @@ class Component:
 def merge_chains(main, *components):
     """Merge multiple chains returned by the components"""
     merged = {}
-    components = [main]+list(reversed(components))
+    components = [main] + list(reversed(components))
 
     # First of all, merge all the subchains of the different components
     # together -- This is a separate step so the order is preserved

--- a/botogram/hooks.py
+++ b/botogram/hooks.py
@@ -18,10 +18,10 @@ class Hook:
     def __init__(self, func, component, args=None):
         prefix = ""
         if component.component_name:
-            prefix = component.component_name+"::"
+            prefix = component.component_name + "::"
 
         self.func = func
-        self.name = prefix+func.__name__
+        self.name = prefix + func.__name__
         self.component = component
         self.component_id = component._component_id
 
@@ -32,7 +32,7 @@ class Hook:
         return rebuild, (self.__class__, self.func, self.component, self._args)
 
     def __repr__(self):
-        return "<"+self.__class__.__name__+" \""+self.name+"\">"
+        return "<" + self.__class__.__name__ + " \"" + self.name + "\">"
 
     def _after_init(self, args):
         """Prepare the object"""
@@ -167,7 +167,7 @@ class CommandHook(Hook):
             raise ValueError("Invalid command name: %s" % args["name"])
 
         # This regex will match all commands pointed to this bot
-        self._regex = re.compile(r'^\/'+args["name"]+r'(@[a-zA-Z0-9_]+)?'
+        self._regex = re.compile(r'^\/' + args["name"] + r'(@[a-zA-Z0-9_]+)?'
                                  r'( .*)?$')
 
     def _call(self, bot, update):
@@ -178,7 +178,7 @@ class CommandHook(Hook):
         match = self._regex.match(text)
         if not match:
             return
-        if match.group(1) and match.group(1) != "@"+bot.itself.username:
+        if match.group(1) and match.group(1) != "@" + bot.itself.username:
             return
 
         args = _command_args_split_re.split(text)[1:]

--- a/botogram/objects/__init__.py
+++ b/botogram/objects/__init__.py
@@ -31,7 +31,7 @@ class User(BaseObject, mixins.ChatMixin):
         """Get the full name of the user"""
         result = self.first_name
         if self.last_name is not None:
-            result += " "+self.last_name
+            result += " " + self.last_name
 
         return result
 
@@ -99,7 +99,7 @@ class Chat(BaseObject, mixins.ChatMixin):
         elif self.first_name is not None:
             result = self.first_name
             if self.last_name is not None:
-                result += " "+self.last_name
+                result += " " + self.last_name
 
         return result
 
@@ -145,12 +145,12 @@ class Photo(mixins.FileMixin):
         # Calculate the smaller and the biggest sizes
         with_size = {}
         for size in self.sizes:
-            with_size[size.height*size.width] = size
+            with_size[size.height * size.width] = size
         self.smallest = with_size[min(with_size.keys())]
         self.biggest = with_size[max(with_size.keys())]
 
         # Publish all the attributes of the biggest-size photo
-        attrs = list(PhotoSize.required.keys())+list(PhotoSize.optional.keys())
+        attrs = list(PhotoSize.required.keys()) + list(PhotoSize.optional.keys())
         for attr in attrs:
             setattr(self, attr, getattr(self.biggest, attr))
 

--- a/botogram/objects/base.py
+++ b/botogram/objects/base.py
@@ -58,7 +58,7 @@ class BaseObject:
         self._api = api
 
         # Recursively set the API
-        for key in list(self.required.keys())+list(self.optional.keys()):
+        for key in list(self.required.keys()) + list(self.optional.keys()):
             # Be sure to use the right key
             if key in self.replace_keys:
                 key = self.replace_keys[key]

--- a/botogram/runner/ipc.py
+++ b/botogram/runner/ipc.py
@@ -250,7 +250,7 @@ def _write_on_socket(conn, data):
     """Write a chunk of data on a connection"""
     remaining = len(data)
     while remaining > 0:
-        sent = conn.send(data[len(data)-remaining:])
+        sent = conn.send(data[len(data) - remaining:])
         if sent == 0:
             raise EOFError("Broken socket!")
 

--- a/botogram/runner/processes.py
+++ b/botogram/runner/processes.py
@@ -191,7 +191,7 @@ class UpdaterProcess(BaseProcess):
 
         try:
             updates = self.bot.api.call("getUpdates", {
-                "offset": self.last_id+1,
+                "offset": self.last_id + 1,
                 "timeout": 1,
             }, expect=objects.Updates)
         except (api.APIError, ValueError, TypeError) as e:

--- a/botogram/tasks.py
+++ b/botogram/tasks.py
@@ -37,7 +37,7 @@ class TimerTask(BaseTask):
         if current is None:
             current = time.time()
 
-        res = self.last_run+self.interval <= current
+        res = self.last_run + self.interval <= current
 
         # Increment the last_run if the result is True
         if res:

--- a/botogram/utils.py
+++ b/botogram/utils.py
@@ -34,7 +34,7 @@ warn_logger = logbook.Logger("botogram's code warnings")
 def _deprecated_message(name, removed_on, fix, back):
     before = "%s will be removed in botogram %s." % (name, removed_on)
     after = "Fix: %s" % fix
-    warn(back-1, before, after)
+    warn(back - 1, before, after)
 
 
 def deprecated(name, removed_on, fix):
@@ -60,7 +60,7 @@ class DeprecatedAttributes:
 
         if key in deprecated:
             _deprecated_message(
-                get("__class__").__name__+"."+key,
+                get("__class__").__name__ + "." + key,
                 deprecated[key]["removed_on"],
                 deprecated[key]["fix"],
                 -2,
@@ -79,15 +79,15 @@ def warn(stack_pos, before_message, after_message=None):
     if sys.version_info[:3] == (3, 5, 0):
         stack_pos -= 1
 
-    frame = traceback.extract_stack()[stack_pos-1]
+    frame = traceback.extract_stack()[stack_pos - 1]
     at_message = "At: %s (line %s)" % (frame[0], frame[1])
 
     warn_logger.warn(before_message)
     if after_message is not None:
         warn_logger.warn(at_message)
-        warn_logger.warn(after_message+"\n")
+        warn_logger.warn(after_message + "\n")
     else:
-        warn_logger.warn(at_message+"\n")
+        warn_logger.warn(at_message + "\n")
 
 
 def wraps(func):

--- a/tasks.py
+++ b/tasks.py
@@ -225,9 +225,10 @@ def test():
 @invoke.task
 def lint():
     """Lint the source code"""
+    FLAKE8_OPTIONS = "--select=E226"
     env = create_env("lint", requirements=True)
 
-    invoke.run("%s/bin/flake8 %s" % (env, PROJECT))
+    invoke.run("%s/bin/flake8 %s %s" % (env, FLAKE8_OPTIONS, PROJECT))
 
 
 #

--- a/tasks.py
+++ b/tasks.py
@@ -276,4 +276,4 @@ def deps_compile():
 
     for file in glob.glob(os.path.join(BASE, "requirements-*.in")):
         invoke.run("%s/bin/pip-compile %s > %s" % (env, os.path.abspath(file),
-                   os.path.abspath(file)[:-3]+".txt"))
+                   os.path.abspath(file)[:-3] + ".txt"))


### PR DESCRIPTION
E226 (missing whitespace around arithmetic operator) is considered optional in default flake8 configuration. In this PR we enforce E226 checks in `invoke lint` and fix all E226 errors. More details about E226 can be found [at the actual PEP-8](https://www.python.org/dev/peps/pep-0008/#id24).