### PR TITLE
Channel posts and edited channel posts support

### DIFF
--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -71,6 +71,10 @@ class Bot(frozenbot.FrozenBot):
         self.register_update_processor("message", messages.process_message)
         self.register_update_processor("edited_message",
                                        messages.process_edited_message)
+        self.register_update_processor("channel_post",
+                                       messages.process_channel_post)
+        self.register_update_processor("channel_post",
+                                       messages.process_edited_channel_post)
 
         self._bot_id = str(uuid.uuid4())
 

--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -73,7 +73,7 @@ class Bot(frozenbot.FrozenBot):
                                        messages.process_edited_message)
         self.register_update_processor("channel_post",
                                        messages.process_channel_post)
-        self.register_update_processor("channel_post",
+        self.register_update_processor("edited_channel_post",
                                        messages.process_edited_channel_post)
 
         self._bot_id = str(uuid.uuid4())
@@ -146,6 +146,16 @@ class Bot(frozenbot.FrozenBot):
     def message_edited(self, func):
         """Add a message edited hook"""
         self._main_component.add_message_edited_hook(func)
+        return func
+
+    def channel_post(self, func):
+        """Add a channel post hook"""
+        self._main_component.add_channel_post_hook(func)
+        return func
+
+    def edited_channel_post(self, func):
+        """Add a edited channel post hook"""
+        self._main_component.add_edited_channel_post_hook(func)
         return func
 
     def command(self, name, hidden=False, order=0):

--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -74,7 +74,7 @@ class Bot(frozenbot.FrozenBot):
         self.register_update_processor("channel_post",
                                        messages.process_channel_post)
         self.register_update_processor("edited_channel_post",
-                                       messages.process_edited_channel_post)
+                                       messages.process_channel_post_edited)
 
         self._bot_id = str(uuid.uuid4())
 
@@ -153,9 +153,9 @@ class Bot(frozenbot.FrozenBot):
         self._main_component.add_channel_post_hook(func)
         return func
 
-    def edited_channel_post(self, func):
+    def channel_post_edited(self, func):
         """Add a edited channel post hook"""
-        self._main_component.add_edited_channel_post_hook(func)
+        self._main_component.add_channel_post_edited_hook(func)
         return func
 
     def command(self, name, hidden=False, order=0):

--- a/botogram/components.py
+++ b/botogram/components.py
@@ -169,7 +169,7 @@ class Component:
         self.__channel_post_hooks.append(hook)
 
     def add_edited_channel_post_hook(self, func):
-        """Add a channel post hook"""
+        """Add an edited channel post hook"""
         if not callable(func):
             raise ValueError("A edited channel post hook must be callable")
 

--- a/botogram/components.py
+++ b/botogram/components.py
@@ -32,6 +32,8 @@ class Component:
         self.__timers = []
         self.__chat_unavailable_hooks = []
         self.__messages_edited_hooks = []
+        self.__channel_post_hooks = []
+        self.__edited_channel_post_hooks = []
 
         self._component_id = str(uuid.uuid4())
 
@@ -158,6 +160,22 @@ class Component:
         hook = hooks.MessageEditedHook(func, self)
         self.__messages_edited_hooks.append(hook)
 
+    def add_channel_post_hook(self, func):
+        """Add a channel post hook"""
+        if not callable(func):
+            raise ValueError("A channel post hook must be callable")
+
+        hook = hooks.ChannelPostHook(func, self)
+        self.__channel_post_hooks.append(hook)
+
+    def add_edited_channel_post_hook(self, func):
+        """Add a channel post hook"""
+        if not callable(func):
+            raise ValueError("A edited channel post hook must be callable")
+
+        hook = hooks.EditedChannelPostHook(func, self)
+        self.__edited_channel_post_hooks.append(hook)
+
     def _add_no_commands_hook(self, func):
         """Register an hook which will be executed when no commands matches"""
         if not callable(func):
@@ -181,6 +199,8 @@ class Component:
             "tasks": [self.__timers],
             "chat_unavalable_hooks": [self.__chat_unavailable_hooks],
             "messages_edited": [self.__messages_edited_hooks],
+            "channel_post": [self.__channel_post_hooks],
+            "edited_channel_post": [self.__edited_channel_post_hooks]
         }
 
     def _get_commands(self):

--- a/botogram/components.py
+++ b/botogram/components.py
@@ -33,7 +33,7 @@ class Component:
         self.__chat_unavailable_hooks = []
         self.__messages_edited_hooks = []
         self.__channel_post_hooks = []
-        self.__edited_channel_post_hooks = []
+        self.__channel_post_edited_hooks = []
 
         self._component_id = str(uuid.uuid4())
 
@@ -168,13 +168,13 @@ class Component:
         hook = hooks.ChannelPostHook(func, self)
         self.__channel_post_hooks.append(hook)
 
-    def add_edited_channel_post_hook(self, func):
+    def add_channel_post_edited_hook(self, func):
         """Add an edited channel post hook"""
         if not callable(func):
             raise ValueError("A edited channel post hook must be callable")
 
         hook = hooks.EditedChannelPostHook(func, self)
-        self.__edited_channel_post_hooks.append(hook)
+        self.__channel_post_edited_hooks.append(hook)
 
     def _add_no_commands_hook(self, func):
         """Register an hook which will be executed when no commands matches"""
@@ -200,7 +200,7 @@ class Component:
             "chat_unavalable_hooks": [self.__chat_unavailable_hooks],
             "messages_edited": [self.__messages_edited_hooks],
             "channel_post": [self.__channel_post_hooks],
-            "edited_channel_post": [self.__edited_channel_post_hooks]
+            "channel_post_edited": [self.__channel_post_edited_hooks]
         }
 
     def _get_commands(self):

--- a/botogram/hooks.py
+++ b/botogram/hooks.py
@@ -211,6 +211,21 @@ class MessageEditedHook(Hook):
         return bot._call(self.func, self.component_id, chat=message.chat,
                          message=message)
 
+class ChannelPostHook(Hook):
+    """Underlying hook for @bot.channel_post"""
+    
+    def _call(self, bot, update):
+        message = update.channel_post
+        return bot._call(self.func, self.component_id, chat=message.chat,
+                         message=message)
+
+class EditedChannelPostHook(Hook):
+    """Underlying hook for @bot.edited_channel_post"""
+    
+    def _call(self, bot, update):
+        message = update.edited_channel_post
+        return bot._call(self.func, self.component_id, chat=message.chat,
+                         message=message)
 
 class TimerHook(Hook):
     """Underlying hook for a timer"""

--- a/botogram/hooks.py
+++ b/botogram/hooks.py
@@ -222,7 +222,7 @@ class ChannelPostHook(Hook):
 
 
 class EditedChannelPostHook(Hook):
-    """Underlying hook for @bot.edited_channel_post"""
+    """Underlying hook for @bot.channel_post_edited"""
 
     def _call(self, bot, update):
         message = update.edited_channel_post

--- a/botogram/hooks.py
+++ b/botogram/hooks.py
@@ -211,21 +211,24 @@ class MessageEditedHook(Hook):
         return bot._call(self.func, self.component_id, chat=message.chat,
                          message=message)
 
+
 class ChannelPostHook(Hook):
     """Underlying hook for @bot.channel_post"""
-    
+
     def _call(self, bot, update):
         message = update.channel_post
         return bot._call(self.func, self.component_id, chat=message.chat,
                          message=message)
 
+
 class EditedChannelPostHook(Hook):
     """Underlying hook for @bot.edited_channel_post"""
-    
+
     def _call(self, bot, update):
         message = update.edited_channel_post
         return bot._call(self.func, self.component_id, chat=message.chat,
                          message=message)
+
 
 class TimerHook(Hook):
     """Underlying hook for a timer"""

--- a/botogram/messages.py
+++ b/botogram/messages.py
@@ -55,9 +55,9 @@ def process_channel_post(bot, chains, update):
                      update.update_id)
 
 
-def process_edited_channel_post(bot, chains, update):
+def process_channel_post_edited(bot, chains, update):
     """Process an edited channel post"""
-    for hook in chains["edited_channel_post"]:
+    for hook in chains["channel_post_edited"]:
         bot.logger.debug("Processing edited channel post in update #%s with"
                          "the hook %s..." % (update.update_id, hook.name))
 

--- a/botogram/messages.py
+++ b/botogram/messages.py
@@ -42,7 +42,7 @@ def process_edited_message(bot, chains, update):
 def process_channel_post(bot, chains, update):
     """Process a channel post"""
     for hook in chains["channel_post"]:
-        bot.logger.debug("Processing channel_post in update #%s with the "
+        bot.logger.debug("Processing channel post in update #%s with the "
                          "hook %s..." % (update.update_id, hook.name))
 
         result = hook.call(bot, update)
@@ -58,7 +58,7 @@ def process_channel_post(bot, chains, update):
 def process_edited_channel_post(bot, chains, update):
     """Process an edited channel post"""
     for hook in chains["edited_channel_post"]:
-        bot.logger.debug("Processing edited_channel_post in update #%s with"
+        bot.logger.debug("Processing edited channel post in update #%s with"
                          "the hook %s..." % (update.update_id, hook.name))
 
         result = hook.call(bot, update)

--- a/botogram/messages.py
+++ b/botogram/messages.py
@@ -38,6 +38,7 @@ def process_edited_message(bot, chains, update):
     bot.logger.debug("No hook actually processed the #%s update." %
                      update.update_id)
 
+
 def process_channel_post(bot, chains, update):
     """Process a channel post"""
     for hook in chains["channel_post"]:
@@ -52,12 +53,13 @@ def process_channel_post(bot, chains, update):
 
     bot.logger.debug("No hook actually processed the #%s update." %
                      update.update_id)
-    
+
+
 def process_edited_channel_post(bot, chains, update):
     """Process an edited channel post"""
     for hook in chains["edited_channel_post"]:
-        bot.logger.debug("Processing edited_channel_post in update #%s with the "
-                         "hook %s..." % (update.update_id, hook.name))
+        bot.logger.debug("Processing edited_channel_post in update #%s with"
+                         "the hook %s..." % (update.update_id, hook.name))
 
         result = hook.call(bot, update)
         if result is True:

--- a/botogram/messages.py
+++ b/botogram/messages.py
@@ -37,3 +37,33 @@ def process_edited_message(bot, chains, update):
 
     bot.logger.debug("No hook actually processed the #%s update." %
                      update.update_id)
+
+def process_channel_post(bot, chains, update):
+    """Process a channel post"""
+    for hook in chains["channel_post"]:
+        bot.logger.debug("Processing channel_post in update #%s with the "
+                         "hook %s..." % (update.update_id, hook.name))
+
+        result = hook.call(bot, update)
+        if result is True:
+            bot.logger.debug("Update %s was just processed by the %s hook." %
+                             (update.update_id, hook.name))
+            return
+
+    bot.logger.debug("No hook actually processed the #%s update." %
+                     update.update_id)
+    
+def process_edited_channel_post(bot, chains, update):
+    """Process an edited channel post"""
+    for hook in chains["edited_channel_post"]:
+        bot.logger.debug("Processing edited_channel_post in update #%s with the "
+                         "hook %s..." % (update.update_id, hook.name))
+
+        result = hook.call(bot, update)
+        if result is True:
+            bot.logger.debug("Update %s was just processed by the %s hook." %
+                             (update.update_id, hook.name))
+            return
+
+    bot.logger.debug("No hook actually processed the #%s update." %
+                     update.update_id)

--- a/botogram/objects/updates.py
+++ b/botogram/objects/updates.py
@@ -23,6 +23,8 @@ class Update(BaseObject):
     optional = {
         "message": Message,
         "edited_message": Message,
+        "channel_post": Message,
+        "edited_channel_post": Message
     }
     _check_equality_ = "update_id"
 

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -216,7 +216,7 @@ components.
 
       .. versionadded:: 0.4
 
-    .. py:decoratormethod:: edited_channel_post
+    .. py:decoratormethod:: channel_post_edited
 
       This decorator receive edited messages from channels, with new Telegram Bot API update
       2.3
@@ -232,8 +232,8 @@ components.
 
       .. code-block:: python
 
-        @bot.edited_channel_post
-        def edit_channel_post(chat, message):
+        @bot.channel_post_edited
+        def channel_post_edited(chat, message):
             message.reply("Why you edited this post? It was so cool :(")
 
       .. versionadded:: 0.4

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -194,6 +194,50 @@ components.
 
       .. versionadded:: 0.3
 
+   .. py:decoratormethod:: channel_post
+
+      This decorator receive messages from channels, with new Telegram Bot API update
+      2.3
+
+      You can :ref:`request the following arguments <bot-structure-hooks-args>`
+      in the decorated functions:
+
+      * **chat**: the chat in which the channel post was originally sent (instance
+        of :py:class:`~botogram.Chat`)
+
+      * **message**: the message (instance of
+        :py:class:`~botogram.Message`)
+
+      .. code-block:: python
+
+        @bot.channel_post
+        def channel_post(chat, message):
+            message.reply("This post is cool")
+
+      .. versionadded:: 0.3
+
+    .. py:decoratormethod:: channel_post
+
+      This decorator receive messages from channels, with new Telegram Bot API update
+      2.3
+
+      You can :ref:`request the following arguments <bot-structure-hooks-args>`
+      in the decorated functions:
+
+      * **chat**: the chat in which the channel post was originally sent (instance
+        of :py:class:`~botogram.Chat`)
+
+      * **message**: the (new) edited message (instance of
+        :py:class:`~botogram.Message`)
+
+      .. code-block:: python
+
+        @bot.edited_channel_post
+        def edit_channel_post(chat, message):
+            message.reply("Why you edited this post? It was so cool :(")
+
+      .. versionadded:: 0.3
+
    .. py:decoratormethod:: command(name, [hidden=False, order=0])
 
       This decorator register a new command, and calls the decorated function

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -214,11 +214,11 @@ components.
         def channel_post(chat, message):
             message.reply("This post is cool")
 
-      .. versionadded:: 0.3
+      .. versionadded:: 0.4
 
-    .. py:decoratormethod:: channel_post
+    .. py:decoratormethod:: edited_channel_post
 
-      This decorator receive messages from channels, with new Telegram Bot API update
+      This decorator receive edited messages from channels, with new Telegram Bot API update
       2.3
 
       You can :ref:`request the following arguments <bot-structure-hooks-args>`
@@ -236,7 +236,7 @@ components.
         def edit_channel_post(chat, message):
             message.reply("Why you edited this post? It was so cool :(")
 
-      .. versionadded:: 0.3
+      .. versionadded:: 0.4
 
    .. py:decoratormethod:: command(name, [hidden=False, order=0])
 


### PR DESCRIPTION
With new [Telegram Bot API Update (2.3)](https://core.telegram.org/bots/api#recent-changes) now bots can receive messages _(updates)_ from **channels**
There are two types of updates:

- **Channel post**: returns `Chat` and `Message` objects when the channel posts a new message.
You can process this by doing:
```
@bot.channel_post
def channel_post(chat, message):
    # things
```
- **Edited channel post**: returns `Chat` and `Message` objects when a channel post was edited
You can process this by doing:
```
@bot.edited_channel_post
def edited_channel_post(chat, message):
    # things
```
