### PR TITLE
Add a timeout to requests

### DIFF
--- a/botogram/api.py
+++ b/botogram/api.py
@@ -95,7 +95,8 @@ class TelegramAPI:
     def call(self, method, params=None, files=None, expect=None):
         """Call a method of the API"""
         url = self._endpoint + "bot%s/%s" % (self._api_key, method)
-        response = self._session().get(url, params=params, files=files, timeout=10)
+        response = self._session().get(url, params=params, files=files,
+                                       timeout=10)
         content = response.json()
 
         if not content["ok"]:

--- a/botogram/api.py
+++ b/botogram/api.py
@@ -95,7 +95,7 @@ class TelegramAPI:
     def call(self, method, params=None, files=None, expect=None):
         """Call a method of the API"""
         url = self._endpoint + "bot%s/%s" % (self._api_key, method)
-        response = self._session().get(url, params=params, files=files)
+        response = self._session().get(url, params=params, files=files, timeout=10)
         content = response.json()
 
         if not content["ok"]:

--- a/docs/changelog/0.4.rst
+++ b/docs/changelog/0.4.rst
@@ -19,6 +19,8 @@ Release description not yet written.
 New features
 ------------
 
+* Fix inability to fetch updates and stop the runner after an internet connection outage.
+
 * Added ability to disable the link preview in ``/help``.
 
   * New parameter :py:attr:`botogram.Bot.link_preview_in_help`


### PR DESCRIPTION
By default requests never times out, the problems with this are:

* The bot won't work after the internet connection comes back.
* If the internet connection goes out the only way to stop the bot will be to kill the process.