### PR TITLE
Delete messages

### DIFF
--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -184,6 +184,17 @@ class ChatMixin:
 
         return self._api.call("sendContact", args, expect=_objects().Message)
 
+    @_require_api
+    def delete_message(self, message):
+        """Delete a message from chat"""
+        if hasattr(message, "message_id"):
+            message = message.message_id
+
+        return self._api.call("deleteMessage", {
+            "chat_id": self.id,
+            "message_id": message,
+        })
+
 
 class MessageMixin:
     """Add some methods for messages"""
@@ -283,6 +294,14 @@ class MessageMixin:
     def reply_with_contact(self, *args, **kwargs):
         """Reply with a contact to the current message"""
         return self.chat.send_contact(*args, reply_to=self, **kwargs)
+
+    @_require_api
+    def delete(self):
+        """Delete the message"""
+        return self._api.call("deleteMessage", {
+            "chat_id": self.chat.id,
+            "message_id": self.message_id,
+        })
 
 
 class FileMixin:

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -372,6 +372,16 @@ about its business.
 
       .. versionadded:: 0.3
 
+   .. py:method:: delete_message(message)
+
+      Delete the message with the provided ID or :py:class:`~botogram.Message` object.
+      A message can be deleted only if is sent by the bot or sent in a supergroup by an user where the bot is admin.
+      It can also be deleted if it's one of the supported service messages.
+
+      :param message: The message to delete (can be an ID too)
+
+      .. versionadded:: 0.4
+
 .. py:class:: botogram.Chat
 
    This class represents a Telegram chat.
@@ -1273,6 +1283,14 @@ about its business.
       :param object extra: An extra reply interface object to attach.
 
       .. versionadded:: 0.3
+
+   .. py:method:: delete()
+
+      Delete this message.
+      A message can be deleted only if is sent by the bot or sent in a supergroup by an user where the bot is admin.
+      It can also be deleted if it's one of the supported service messages.
+
+      .. versionadded:: 0.4
 
    .. py:method:: edit_caption(caption, [extra=None])
 


### PR DESCRIPTION
In upcoming **Telegram bots API upgrade**, bots will able to **delete messages** sent by itself and sent by users in a supergroup where the bot is admin.
I've added **two new methods**, `message.delete()` and `chat.delete_message()`.

Example usage:
```python
@bot.command("delete")
def delete(chat, message, args):
   if message.reply_to_message:
        message.reply_to_message.delete()
   else:
        message.reply("Reply to a message to delete it!")
        return

   message.delete()
   msg = chat.send("Message deleted, sir!")
   time.sleep(5)
   chat.delete_message(msg)  # Or msg.delete()
```