### PR TITLE
Fix to stdout_logfile_maxbytes values

### DIFF
--- a/docs/deploy/supervisord.rst
+++ b/docs/deploy/supervisord.rst
@@ -112,7 +112,7 @@ distributions is located at ``/etc/supervisord.conf``::
 
    redirect_stderr=true
    stdout_logfile=/home/telegrambot/mybot.log
-   stdout_logfile_maxbytes=10M
+   stdout_logfile_maxbytes=10MB
 
 This will create a process named ``mybot`` with some standard configuration:
 


### PR DESCRIPTION
ONLY suffix multipliers like “KB”, “MB”, and “GB” can be used in the value.