### PR TITLE
Accounts deleted by inactivity incorrectly raised an APIError

### DIFF
--- a/botogram/api.py
+++ b/botogram/api.py
@@ -127,9 +127,9 @@ class TelegramAPI:
                     reason = "blocked"
 
                 # This happens when the user deleted its account
-                elif status == 403 and "deleted" in message:
+                elif status == 403 and "deactivated" in message:
                     # Error code # 403
-                    # Forbidden: user is deleted
+                    # Forbidden: user is deactivated
                     reason = "account_deleted"
 
                 # This happens, as @BotSupport says, when the Telegram API

--- a/docs/changelog/0.4.rst
+++ b/docs/changelog/0.4.rst
@@ -7,6 +7,20 @@ Changelog of botogram 0.4.x
 
 Here you can find all the changes in the botogram 0.4.x releases.
 
+.. _changelog-0.4.1:
+
+botogram 0.4.1
+==============
+
+*Alpha release, not yet released.*
+
+Release description not yet written.
+
+Bug fixes
+---------
+
+* Accounts deleted by inactivity incorrectly raised an APIError instead of a ChatUnavailableError
+
 .. _changelog-0.4:
 
 botogram 0.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,7 +80,7 @@ def test_unavailable_chats(api, mock_req):
         },
         "sendVoice": {
             "ok": False, "error_code": 403,
-            "description": "Forbidden: user is deleted",
+            "description": "Forbidden: user is deactivated",
         },
         "sendChatAction": {
             "ok": False, "error_code": 400,


### PR DESCRIPTION
For a long time trying to write to a user deleted by inactivity incorrectly raised an APIError instead of a ChatUnavailableError