### PR TITLE
Allow users to programmatically override default i18n strings

### DIFF
--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -59,6 +59,7 @@ class Bot(frozenbot.FrozenBot):
 
         self._lang = ""
         self._lang_inst = None
+        self.override_i18n = {}
 
         # Support for the old, deprecated bot.hide_commands
         self._hide_commands = []
@@ -273,7 +274,7 @@ class Bot(frozenbot.FrozenBot):
                                    self._commands, chains, self._scheduler,
                                    self._main_component._component_id,
                                    self._bot_id, self._shared_memory,
-                                   self._update_processors)
+                                   self._update_processors, self.override_i18n)
 
     @property
     def lang(self):

--- a/botogram/frozenbot.py
+++ b/botogram/frozenbot.py
@@ -36,7 +36,7 @@ class FrozenBot:
                  after_help, link_preview_in_help,
                  validate_callback_signatures, process_backlog, lang, itself,
                  commands_re, commands, chains, scheduler, main_component_id,
-                 bot_id, shared_memory, update_processors):
+                 bot_id, shared_memory, update_processors, override_i18n):
         # This attribute should be added with the default setattr, because is
         # needed by the custom setattr
         object.__setattr__(self, "_frozen", False)
@@ -61,6 +61,7 @@ class FrozenBot:
         self._update_processors = update_processors
         self._commands = {name: command.for_bot(self)
                           for name, command in commands.items()}
+        self.override_i18n = override_i18n
 
         # Setup the logger
         self.logger = logbook.Logger('botogram bot')
@@ -82,7 +83,7 @@ class FrozenBot:
             self.validate_callback_signatures, self.process_backlog, self.lang,
             self.itself, self._commands_re, self._commands, self._chains,
             self._scheduler, self._main_component_id, self._bot_id,
-            self._shared_memory, self._update_processors,
+            self._shared_memory, self._update_processors, self.override_i18n
         )
         return restore, args
 
@@ -240,7 +241,12 @@ class FrozenBot:
 
     def _(self, message, **args):
         """Translate a string"""
-        return self._lang_inst.gettext(message) % args
+        # Check if the message has been overridden
+        if message in self.override_i18n:
+            return self.override_i18n[message] % args
+        # Otherwise try to return the original message
+        else:
+            return self._lang_inst.gettext(message) % args
 
     # And some internal methods used by botogram
 

--- a/botogram/frozenbot.py
+++ b/botogram/frozenbot.py
@@ -83,7 +83,7 @@ class FrozenBot:
             self.validate_callback_signatures, self.process_backlog, self.lang,
             self.itself, self._commands_re, self._commands, self._chains,
             self._scheduler, self._main_component_id, self._bot_id,
-            self._shared_memory, self._update_processors, self.override_i18n
+            self._shared_memory, self._update_processors, self.override_i18n,
         )
         return restore, args
 

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -83,6 +83,13 @@ components.
       The :py:class:`botogram.User` representation of the bot's user account.
       From this you can access its id, username and more.
 
+   .. py:attribute:: override_i18n
+
+      A dictionary that allows to override default i18n messages by associating
+      the default ``msgid`` string of a message with its alternative.
+
+      .. versionadded:: 0.4.1
+
    .. py:decoratormethod:: before_processing
 
       Functions decorated with this decorator will be called before an update

--- a/docs/changelog/0.4.rst
+++ b/docs/changelog/0.4.rst
@@ -16,6 +16,13 @@ botogram 0.4.1
 
 Release description not yet written.
 
+New features
+------------
+
+* Added ability to override default i18n messages
+
+   * New attribute :py:attr:`botogram.Bot.override_i18n`
+
 Bug fixes
 ---------
 

--- a/i18n/botogram.pot
+++ b/i18n/botogram.pot
@@ -1,70 +1,71 @@
 # Translations template for botogram.
-# Copyright (C) 2016 Pietro Albini <pietro@pietroalbini.io>
+# Copyright (C) 2017 Pietro Albini <pietro@pietroalbini.io>
 # This file is distributed under the same license as the botogram project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: botogram 1.0.dev0\n"
 "Report-Msgid-Bugs-To: https://github.com/pietroalbini/botogram/issues\n"
-"POT-Creation-Date: 2016-03-30 22:31+0200\n"
+"POT-Creation-Date: 2017-10-06 19:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.1.1\n"
+"Generated-By: Babel 2.3.4\n"
 
-#: botogram/defaults.py:32
+#: botogram/defaults.py:46
 msgid "Use /help to get a list of all the commands."
 msgstr ""
 
-#: botogram/defaults.py:39
+#: botogram/defaults.py:53
 msgid "Start using the bot."
 msgstr ""
 
-#: botogram/defaults.py:40
+#: botogram/defaults.py:54
 msgid "This shows a greeting message."
 msgstr ""
 
-#: botogram/defaults.py:48
+#: botogram/defaults.py:62
 msgid "<b>Error!</b> The <code>/help</code> command allows up to one argument."
 msgstr ""
 
-#: botogram/defaults.py:54 botogram/defaults.py:153
+#: botogram/defaults.py:68 botogram/defaults.py:167
 #, python-format
 msgid "<b>Unknown command:</b> <code>/%(name)s</code>"
 msgstr ""
 
-#: botogram/defaults.py:57 botogram/defaults.py:155
+#: botogram/defaults.py:71 botogram/defaults.py:169
 msgid "Use /help to get a list of the commands."
 msgstr ""
 
-#: botogram/defaults.py:78
+#: botogram/defaults.py:93
 msgid "<b>This bot supports those commands:</b>"
 msgstr ""
 
-#: botogram/defaults.py:89 botogram/defaults.py:130
+#: botogram/defaults.py:97 botogram/defaults.py:127
+msgid "No description available."
+msgstr ""
+
+#: botogram/defaults.py:101 botogram/defaults.py:144
 msgid ""
 "You can also use <code>/help &lt;command&gt;</code> to get help about a "
 "specific command."
 msgstr ""
 
-#: botogram/defaults.py:93
+#: botogram/defaults.py:105
 msgid "<i>This bot has no commands.</i>"
 msgstr ""
 
-#: botogram/defaults.py:102 botogram/defaults.py:119
+#: botogram/defaults.py:114 botogram/defaults.py:133
 #, python-format
 msgid "Please contact %(owner)s if you have problems with this bot."
 msgstr ""
 
-#: botogram/defaults.py:129
+#: botogram/defaults.py:143
 msgid "Show this help message."
-msgstr ""
-
-#: botogram/utils.py:144
-msgid "No description available."
 msgstr ""
 

--- a/i18n/langs/en.po
+++ b/i18n/langs/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: botogram 1.0.dev0\n"
 "Report-Msgid-Bugs-To: https://github.com/pietroalbini/botogram/issues\n"
-"POT-Creation-Date: 2016-03-30 22:31+0200\n"
+"POT-Creation-Date: 2017-10-06 19:21+0200\n"
 "PO-Revision-Date: 2015-08-01 17:20+0200\n"
 "Last-Translator: Pietro Albini <pietro@pietroalbini.io>\n"
 "Language: en\n"
@@ -16,56 +16,57 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.1.1\n"
+"Generated-By: Babel 2.3.4\n"
 
-#: botogram/defaults.py:32
+#: botogram/defaults.py:46
 msgid "Use /help to get a list of all the commands."
 msgstr ""
 
-#: botogram/defaults.py:39
+#: botogram/defaults.py:53
 msgid "Start using the bot."
 msgstr ""
 
-#: botogram/defaults.py:40
+#: botogram/defaults.py:54
 msgid "This shows a greeting message."
 msgstr ""
 
-#: botogram/defaults.py:48
+#: botogram/defaults.py:62
 msgid "<b>Error!</b> The <code>/help</code> command allows up to one argument."
 msgstr ""
 
-#: botogram/defaults.py:54 botogram/defaults.py:153
+#: botogram/defaults.py:68 botogram/defaults.py:167
 #, python-format
 msgid "<b>Unknown command:</b> <code>/%(name)s</code>"
 msgstr ""
 
-#: botogram/defaults.py:57 botogram/defaults.py:155
+#: botogram/defaults.py:71 botogram/defaults.py:169
 msgid "Use /help to get a list of the commands."
 msgstr ""
 
-#: botogram/defaults.py:78
+#: botogram/defaults.py:93
 msgid "<b>This bot supports those commands:</b>"
 msgstr ""
 
-#: botogram/defaults.py:89 botogram/defaults.py:130
+#: botogram/defaults.py:97 botogram/defaults.py:127
+msgid "No description available."
+msgstr ""
+
+#: botogram/defaults.py:101 botogram/defaults.py:144
 msgid ""
 "You can also use <code>/help &lt;command&gt;</code> to get help about a "
 "specific command."
 msgstr ""
 
-#: botogram/defaults.py:93
+#: botogram/defaults.py:105
 msgid "<i>This bot has no commands.</i>"
 msgstr ""
 
-#: botogram/defaults.py:102 botogram/defaults.py:119
+#: botogram/defaults.py:114 botogram/defaults.py:133
 #, python-format
 msgid "Please contact %(owner)s if you have problems with this bot."
 msgstr ""
 
-#: botogram/defaults.py:129
+#: botogram/defaults.py:143
 msgid "Show this help message."
 msgstr ""
 
-#: botogram/utils.py:144
-msgid "No description available."
-msgstr ""

--- a/i18n/langs/it.po
+++ b/i18n/langs/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: botogram 1.0.dev0\n"
 "Report-Msgid-Bugs-To: https://github.com/pietroalbini/botogram/issues\n"
-"POT-Creation-Date: 2016-03-30 22:31+0200\n"
+"POT-Creation-Date: 2017-10-06 19:21+0200\n"
 "PO-Revision-Date: 2015-08-01 17:06+0200\n"
 "Last-Translator: Pietro Albini <pietro@pietroalbini.io>\n"
 "Language: it\n"
@@ -16,57 +16,61 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.1.1\n"
+"Generated-By: Babel 2.3.4\n"
 
-#: botogram/defaults.py:32
+#: botogram/defaults.py:46
 msgid "Use /help to get a list of all the commands."
 msgstr "Utilizza /help per ottenere la lista di tutti i comandi."
 
-#: botogram/defaults.py:39
+#: botogram/defaults.py:53
 msgid "Start using the bot."
 msgstr "Inizia ad usare il bot."
 
-#: botogram/defaults.py:40
+#: botogram/defaults.py:54
 msgid "This shows a greeting message."
 msgstr "Questo comando visualizza un messaggio di benvenuto."
 
-#: botogram/defaults.py:48
+#: botogram/defaults.py:62
 msgid "<b>Error!</b> The <code>/help</code> command allows up to one argument."
-msgstr "<b>Errore!</b> Il comando <code>/help</code> non accetta più di un argomento."
+msgstr ""
+"<b>Errore!</b> Il comando <code>/help</code> non accetta più di un "
+"argomento."
 
-#: botogram/defaults.py:54 botogram/defaults.py:153
+#: botogram/defaults.py:68 botogram/defaults.py:167
 #, python-format
 msgid "<b>Unknown command:</b> <code>/%(name)s</code>"
 msgstr "<b>Comando sconosciuto:</b> <code>/%(name)s</code>"
 
-#: botogram/defaults.py:57 botogram/defaults.py:155
+#: botogram/defaults.py:71 botogram/defaults.py:169
 msgid "Use /help to get a list of the commands."
 msgstr "Utilizza /help per ottenere la lista dei comandi."
 
-#: botogram/defaults.py:78
+#: botogram/defaults.py:93
 msgid "<b>This bot supports those commands:</b>"
 msgstr "<b>Questo bot supporta i seguenti comandi:</b>"
 
-#: botogram/defaults.py:89 botogram/defaults.py:130
+#: botogram/defaults.py:97 botogram/defaults.py:127
+msgid "No description available."
+msgstr "Nessuna descrizione disponibile."
+
+#: botogram/defaults.py:101 botogram/defaults.py:144
 msgid ""
 "You can also use <code>/help &lt;command&gt;</code> to get help about a "
 "specific command."
-msgstr "Puoi anche usare <code>/help &lt;comando&gt;</code> per ottenere aiuto su un comando."
+msgstr ""
+"Puoi anche usare <code>/help &lt;comando&gt;</code> per ottenere aiuto su"
+" un comando."
 
-#: botogram/defaults.py:93
+#: botogram/defaults.py:105
 msgid "<i>This bot has no commands.</i>"
 msgstr "<i>Questo bot non ha comandi.</i>"
 
-#: botogram/defaults.py:102 botogram/defaults.py:119
+#: botogram/defaults.py:114 botogram/defaults.py:133
 #, python-format
 msgid "Please contact %(owner)s if you have problems with this bot."
 msgstr "Contatta %(owner)s se hai problemi con questo bot."
 
-#: botogram/defaults.py:129
+#: botogram/defaults.py:143
 msgid "Show this help message."
 msgstr "Visualizza questo messaggio di aiuto."
-
-#: botogram/utils.py:144
-msgid "No description available."
-msgstr "Nessuna descrizione disponibile."
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -31,7 +31,7 @@ def test_bot_creation(api, mock_req):
     # Mock the getMe request
     mock_req({
         "getMe": {"ok": True, "result": {"id": 1, "first_name": "test",
-                  "username": "test_bot"}},
+                                         "username": "test_bot"}},
     })
 
     bot1 = botogram.bot.create(conftest.API_KEY)
@@ -78,16 +78,20 @@ def test_bot_freeze(bot):
 
     assert bot == frozen
 
+
 def test_i18n_override(bot):
-    default_message = botogram.utils.get_language("en").gettext("Use /help to get a list of all the commands.")
+    default_message = botogram.utils.get_language("en") \
+        .gettext("Use /help to get a list of all the commands.")
     override_message = "git gud"
 
     bot.override_i18n = {
         default_message: override_message
     }
 
-    assert bot._("Use /help to get a list of all the commands.") == "git gud"
+    assert bot._("Use /help to get a list of all the commands.") \
+        == override_message
 
     bot.override_i18n = {}
 
-    assert bot._("Use /help to get a list of all the commands.") == default_message
+    assert bot._("Use /help to get a list of all the commands.") \
+        == default_message

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -22,6 +22,7 @@ import copy
 
 import botogram.bot
 import botogram.components
+import botogram.utils
 
 import conftest
 
@@ -76,3 +77,17 @@ def test_bot_freeze(bot):
     frozen = bot.freeze()
 
     assert bot == frozen
+
+def test_i18n_override(bot):
+    default_message = botogram.utils.get_language("en").gettext("Use /help to get a list of all the commands.")
+    override_message = "git gud"
+
+    bot.override_i18n = {
+        default_message: override_message
+    }
+
+    assert bot._("Use /help to get a list of all the commands.") == "git gud"
+
+    bot.override_i18n = {}
+
+    assert bot._("Use /help to get a list of all the commands.") == default_message


### PR DESCRIPTION
Implements the API set out in #47 to allow botogram users to override i18n messages without the need to recompile the `.po` files. This change may conflict with #85, but the PR looks pretty dead. This also contributes towards the completion of the #46 roadmap.

When the `FrozenBot._` method is called it will first look up the `msgid` in the `i18n_override` map, before falling back to `_lang_inst.gettext`. This actually allows users to define custom messages stored in the bot instance and is independent from the language the bot is using.

While not strictly related to #47, `.po` files have been rebuilt from sources as they were missing some new messages and used outdated references.