### PR TITLE
Fix docs code typos and deprecated code

### DIFF
--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -344,7 +344,7 @@ components.
 
          @bot.timer(1)
          def spammer(bot):
-             bot.send(USER_ID, "Hey!")
+             bot.chat(USER_ID).send("Hey!")
 
       :param int interval: The execution interval, in seconds.
 

--- a/docs/api/buttons.rst
+++ b/docs/api/buttons.rst
@@ -34,7 +34,7 @@ information about them.
           btns = botogram.Buttons()
           btns[0].url("Visit example.com", "http://www.example.com")
           btns[1].url("example.net", "http://www.example.net")
-          btns[2].url("example.org", "http://www.example.org")
+          btns[1].url("example.org", "http://www.example.org")
 
           chat.send("Check out some example sites!", attach=btns)
 
@@ -71,7 +71,7 @@ information about them.
 
          btns = botogram.Buttons()
          btns[0].callback("Commit changes", "commit")
-         btns[1].callback("Checkout master", "checkout", "master")
+         btns[0].callback("Checkout master", "checkout", "master")
 
       :param str label: The label of the button shown to the user
       :param str callback: The internal name of the callback

--- a/docs/api/buttons.rst
+++ b/docs/api/buttons.rst
@@ -34,7 +34,7 @@ information about them.
           btns = botogram.Buttons()
           btns[0].url("Visit example.com", "http://www.example.com")
           btns[1].url("example.net", "http://www.example.net")
-          btns[1].url("example.org", "http://www.example.org")
+          btns[2].url("example.org", "http://www.example.org")
 
           chat.send("Check out some example sites!", attach=btns)
 
@@ -71,7 +71,7 @@ information about them.
 
          btns = botogram.Buttons()
          btns[0].callback("Commit changes", "commit")
-         btns[0].callback("Checkout master", "checkout", "master")
+         btns[1].callback("Checkout master", "checkout", "master")
 
       :param str label: The label of the button shown to the user
       :param str callback: The internal name of the callback

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -39,7 +39,7 @@ implement this, with a resolution of one second. Just use the
    @bot.timer(3600)
    def BONG(bot, shared):
        for chat in shared["subs"]:
-           bot.send(chat, "BONG")
+           bot.chat(chat).send("BONG")
 
 If you're working with components, you can instead use the
 :py:meth:`~botogram.Component.add_timer` method of the component instance.

--- a/docs/unavailable-chats.rst
+++ b/docs/unavailable-chats.rst
@@ -105,7 +105,7 @@ can take action without aborting the update processing:
 
        for user in users:
            try:
-               bot.send(user, message)
+               bot.chat(user).send(message)
            except botogram.ChatUnavailableError as e:
                print("Can't send messages to %s (reason: %s)" %
                      (e.chat_id, e.reason))


### PR DESCRIPTION
Replace bot.send(chat, message) with
bot.chat(chat).send(message)

Fix typos in the buttons code