### PR TITLE
Replace botogram.pietroalbini.io with botogram.pietroalbini.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     bot.run()
 ```
 
-You can find the documentation at [botogram.pietroalbini.io][2]. Also, you can
+You can find the documentation at [botogram.pietroalbini.org][2]. Also, you can
 get all the news about botogram in its [Telegram channel][channel].
 
 > Please note botogram currently doesn't support some of the upstream API
@@ -51,6 +51,6 @@ On some Linux systems you might need to wrap the ``invoke install`` command with
 ``sudo``, if you don't have root privileges.
 
 [1]: https://core.telegram.org/bots
-[2]: https://botogram.pietroalbini.io/docs
+[2]: https://botogram.pietroalbini.org/docs
 [3]: http://www.pyinvoke.org
 [channel]: https://telegram.me/botogram_framework

--- a/website/index.html
+++ b/website/index.html
@@ -43,7 +43,7 @@ bot = botogram.create(<span class="cs">"API-KEY"</span>)
                         <li><a href="https://github.com/pietroalbini/botogram">
                             Source code
                         </a></li>
-                        <li><a href="https://botogram.pietroalbini.io/docs">
+                        <li><a href="https://botogram.pietroalbini.org/docs">
                             Documentation
                         </a></li>
                         <li><a href="https://telegram.me/botogram_framework">
@@ -73,14 +73,14 @@ bot = botogram.create(<span class="cs">"API-KEY"</span>)
         <footer>
             <ul>
                 <li>Copyright &copy; 2015-2016
-                    <a href="https://pietroalbini.io">Pietro Albini</a>
+                    <a href="https://pietroalbini.org">Pietro Albini</a>
                 </li>
                 <li>botogram is released under the MIT license.</li>
             </ul>
         </footer>
 
-        <link rel="stylesheet" href="https://assets.pietroalbini.io/fonts/bitter/include.min.css">
-        <link rel="stylesheet" href="https://assets.pietroalbini.io/fonts/dejavu-sans/include.min.css">
-        <link rel="stylesheet" href="https://assets.pietroalbini.io/fonts/hack/include.min.css">
+        <link rel="stylesheet" href="https://assets.pietroalbini.org/fonts/bitter/include.min.css">
+        <link rel="stylesheet" href="https://assets.pietroalbini.org/fonts/dejavu-sans/include.min.css">
+        <link rel="stylesheet" href="https://assets.pietroalbini.org/fonts/hack/include.min.css">
     </body>
 </html>


### PR DESCRIPTION
Some parts of the docs website and the readme were using the old pietroalbini.io domain