### PR TITLE
Add captions in the methods that send media

### DIFF
--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -103,10 +103,12 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_audio(self, path, duration=None, performer=None, title=None,
+    def send_audio(self, path, caption=None, duration=None, performer=None, title=None,
                    reply_to=None, extra=None, attach=None, notify=True):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
         if duration is not None:
             args["duration"] = duration
         if performer is not None:
@@ -120,10 +122,12 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path, duration=None, title=None, reply_to=None,
+    def send_voice(self, path, caption=None, duration=None, title=None, reply_to=None,
                    extra=None, attach=None, notify=True):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
         if duration is not None:
             args["duration"] = duration
 
@@ -148,10 +152,12 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path, reply_to=None, extra=None, attach=None,
+    def send_file(self, path, caption=None, reply_to=None, extra=None, attach=None,
                   notify=True):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
 
         files = {"document": open(path, "rb")}
 

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -122,8 +122,8 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path, caption=None, duration=None, title=None, reply_to=None,
-                   extra=None, attach=None, notify=True):
+    def send_voice(self, path, caption=None, duration=None, title=None,
+                   reply_to=None, extra=None, attach=None, notify=True):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -152,8 +152,8 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path, caption=None, reply_to=None, extra=None, attach=None,
-                  notify=True):
+    def send_file(self, path, caption=None, reply_to=None, extra=None,
+                  attach=None, notify=True):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -103,8 +103,9 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_audio(self, path, caption=None, duration=None, performer=None, title=None,
-                   reply_to=None, extra=None, attach=None, notify=True):
+    def send_audio(self, path, caption=None, duration=None, performer=None,
+                   title=None, reply_to=None, extra=None, attach=None, 
+                   notify=True):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -598,7 +598,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the photo.
       :param str path: The path to the audio track
-      :param str caption The caption of the video
+      :param str caption: The caption of the audio
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -637,7 +637,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the photo.
       :param str path: The path to the voice message
-      :param str caption The caption of the video
+      :param str caption: The caption of the voice message
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object extra: An extra reply interface object to attach
@@ -710,7 +710,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the file
       :param str path: The path to the file
-      :param str caption The caption of the video
+      :param str caption: The caption of the file
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -575,7 +575,7 @@ components.
 
       .. deprecated:: 0.3 it will be removed in botogram 1.0
 
-   .. py:method:: send_audio(chat, path, [duration=None, performer=None, title=None, reply_to=None, extra=None, notify=True])
+   .. py:method:: send_audio(chat, path, [caption=None, duration=None, performer=None, title=None, reply_to=None, extra=None, notify=True])
 
       This method sends an audio track to a specific chat. The chat must be
       identified by its ID, and Telegram applies some restrictions on the chats
@@ -598,6 +598,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the photo.
       :param str path: The path to the audio track
+      :param str caption The caption of the video
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -613,7 +614,7 @@ components.
 
       .. deprecated:: 0.3 it will be removed in botogram 1.0
 
-   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, extra=None, notify=True])
+   .. py:method:: send_voice(chat, path, [caption=None, duration=None, reply_to=None, extra=None, notify=True])
 
       This method sends a voice message to a specific chat. The chat must be
       identified by its ID, and Telegram applies some restrictions on the chats
@@ -636,6 +637,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the photo.
       :param str path: The path to the voice message
+      :param str caption The caption of the video
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object extra: An extra reply interface object to attach
@@ -686,7 +688,7 @@ components.
 
       .. deprecated:: 0.3 it will be removed in botogram 1.0
 
-   .. py:method:: send_file(chat, path, [reply_to=None, extra=None, notify=True])
+   .. py:method:: send_file(chat, path, [caption=None, reply_to=None, extra=None, notify=True])
 
       This method sends a generic file to a specific chat. The chat must be
       identified by its ID, and Telegram applies some restrictions on the chats
@@ -708,6 +710,7 @@ components.
 
       :param int chat: The ID of the chat which should receive the file
       :param str path: The path to the file
+      :param str caption The caption of the video
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.


### PR DESCRIPTION
The argument has been added right after path, just like it is in the telegram documentation.