### PR TITLE
Add captions in send_audio, voice and file

### DIFF
--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -103,10 +103,13 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_audio(self, path, duration=None, performer=None, title=None,
-                   reply_to=None, extra=None, attach=None, notify=True):
+    def send_audio(self, path, caption=None, duration=None, performer=None,
+                   title=None, reply_to=None, extra=None, attach=None,
+                   notify=True):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
         if duration is not None:
             args["duration"] = duration
         if performer is not None:
@@ -120,10 +123,12 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path, duration=None, title=None, reply_to=None,
-                   extra=None, attach=None, notify=True):
+    def send_voice(self, path, caption=None, duration=None, title=None,
+                   reply_to=None, extra=None, attach=None, notify=True):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
         if duration is not None:
             args["duration"] = duration
 
@@ -148,10 +153,12 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path, reply_to=None, extra=None, attach=None,
-                  notify=True):
+    def send_file(self, path, caption=None, reply_to=None, extra=None,
+                  attach=None, notify=True):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
+        if caption is not None:
+            args["caption"] = caption
 
         files = {"document": open(path, "rb")}
 

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -103,9 +103,9 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_audio(self, path, caption=None, duration=None, performer=None,
+    def send_audio(self, path, duration=None, performer=None,
                    title=None, reply_to=None, extra=None, attach=None,
-                   notify=True):
+                   notify=True, caption=None):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -123,8 +123,8 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path, caption=None, duration=None, title=None,
-                   reply_to=None, extra=None, attach=None, notify=True):
+    def send_voice(self, path, duration=None, title=None, reply_to=None,
+                   extra=None, attach=None, notify=True, caption=None):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -153,8 +153,8 @@ class ChatMixin:
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path, caption=None, reply_to=None, extra=None,
-                  attach=None, notify=True):
+    def send_file(self, path, reply_to=None, extra=None,
+                  attach=None, notify=True, caption=None):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -155,7 +155,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_audio(path, [caption=None, duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the audio track found in the *path* to the user. You may optionally
       specify the *duration*, the *performer* and the *title* of the audio
@@ -169,7 +169,6 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the audio track
-      :param str caption: A caption for the audio track.
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -177,6 +176,7 @@ about its business.
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the audio track.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -187,8 +187,12 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+         
+      .. versionchanged:: 0.5
 
-   .. py:method:: send_voice(chat, path, [caption=None, duration=None, reply_to=None, attach=None, extra=None, notify=True])
+         Added support for caption
+
+   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the voice message found in the *path* to the user. You may
       optionally specify the *duration* of the voice message. If the voice
@@ -202,12 +206,12 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the voice message
-      :param str caption: A caption for the voice message.
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the voice message.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -218,6 +222,10 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+         
+      .. versionchanged:: 0.5
+
+         Added support for caption
 
    .. py:method:: send_video(path, [duration=None, caption=None, reply_to=None, attach=None, extra=None, notify=True])
 
@@ -250,7 +258,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_file(path, [caption=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the generic file found in the *path* to the user. If the file you're
       sending is in reply to another message, set *reply_to* to the ID of the
@@ -263,11 +271,11 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the file
-      :param str caption: A caption for the file.
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the file.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -278,6 +286,10 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+         
+      .. versionchanged:: 0.5
+
+         Added support for caption
 
    .. py:method:: send_location(latitude, longitude, [reply_to=None, attach=None, extra=None, notify=True])
 
@@ -731,7 +743,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the audio track found in the *path* to the chat. You may optionally
       specify the *duration*, the *performer* and the *title* of the audio
@@ -752,6 +764,7 @@ about its business.
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the audio track.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -763,7 +776,11 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True])
+      .. versionchanged:: 0.5
+
+         Added support for caption
+
+   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the voice message found in the *path* to the chat. You may
       optionally specify the *duration* of the voice message. If the voice
@@ -782,6 +799,7 @@ about its business.
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the voice message.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -792,6 +810,10 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+
+      .. versionchanged:: 0.5
+
+         Added support for caption
 
    .. py:method:: send_video(path, [duration=None, caption=None, reply_to=None, attach=None, extra=None, notify=True])
 
@@ -824,7 +846,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True, caption=None])
 
       Send the generic file found in the *path* to the chat. If the file you're
       sending is in reply to another message, set *reply_to* to the ID of the
@@ -841,6 +863,7 @@ about its business.
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
       :param bool notify: If you want to trigger the client notification.
+      :param str caption: A caption for the file.
       :returns: The message you sent
       :rtype: ~botogram.Message
 
@@ -851,6 +874,10 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+
+      .. versionchanged:: 0.5
+
+         Added support for caption
 
    .. py:method:: send_location(latitude, longitude, [reply_to=None, attach=None, extra=None, notify=True])
 

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -155,7 +155,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_audio(path, [caption=None, duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True])
 
       Send the audio track found in the *path* to the user. You may optionally
       specify the *duration*, the *performer* and the *title* of the audio
@@ -169,6 +169,7 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the audio track
+      :param str caption: A caption for the audio track.
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -187,7 +188,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_voice(chat, path, [caption=None, duration=None, reply_to=None, attach=None, extra=None, notify=True])
 
       Send the voice message found in the *path* to the user. You may
       optionally specify the *duration* of the voice message. If the voice
@@ -201,6 +202,7 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the voice message
+      :param str caption: A caption for the voice message.
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
@@ -248,7 +250,7 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_file(path, [caption=None, reply_to=None, attach=None, extra=None, notify=True])
 
       Send the generic file found in the *path* to the user. If the file you're
       sending is in reply to another message, set *reply_to* to the ID of the
@@ -261,6 +263,7 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the file
+      :param str caption: A caption for the file.
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach


### PR DESCRIPTION
The argument has been added right after path, just like it is in the telegram documentation.
If there is some other thing to be changed in the documentation, I will do whatever is needed.