### PR TITLE
Add possibility to send files via file_id and url

### DIFF
--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -90,14 +90,17 @@ class ChatMixin:
         return self._api.call("sendMessage", args, expect=_objects().Message)
 
     @_require_api
-    def send_photo(self, path, caption=None, reply_to=None, extra=None,
+    def send_photo(self, path=None, idtg=None, caption=None, reply_to=None, extra=None,
                    attach=None, notify=True):
         """Send a photo"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
             args["caption"] = caption
-
-        files = {"photo": open(path, "rb")}
+        if path is not None:
+            files = {"photo": open(path, "rb")}
+        elif idtg is not None:
+            args["photo"] = idtg
+            files = None
 
         return self._api.call("sendPhoto", args, files,
                               expect=_objects().Message)
@@ -106,6 +109,9 @@ class ChatMixin:
     def send_audio(self, path, duration=None, performer=None,
                    title=None, reply_to=None, extra=None, attach=None,
                    notify=True, caption=None):
+    def send_audio(self, path=None, file_id=None, duration=None,
+                   performer=None, title=None, reply_to=None,
+                   extra=None, attach=None, notify=True, caption=None):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -117,13 +123,17 @@ class ChatMixin:
         if title is not None:
             args["title"] = title
 
-        files = {"audio": open(path, "rb")}
+        if path is not None:
+            files = {"audio": open(path, "rb")}
+        elif idtg is not None:
+            files = None
+            args["audio"] = idtg
 
         return self._api.call("sendAudio", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path, duration=None, title=None, reply_to=None,
+    def send_voice(self, path=None, idtg=None, duration=None, title=None, reply_to=None,
                    extra=None, attach=None, notify=True, caption=None):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
@@ -132,13 +142,17 @@ class ChatMixin:
         if duration is not None:
             args["duration"] = duration
 
-        files = {"voice": open(path, "rb")}
+        if path is not None:
+            files = {"voice": open(path, "rb")}
+        elif idtg is not None:
+            files = None
+            args["voice"] = idtg
 
         return self._api.call("sendVoice", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_video(self, path, duration=None, caption=None, reply_to=None,
+    def send_video(self, path=None, idtg=None, duration=None, caption=None, reply_to=None,
                    extra=None, attach=None, notify=True):
         """Send a video"""
         args = self._get_call_args(reply_to, extra, attach, notify)
@@ -147,20 +161,28 @@ class ChatMixin:
         if caption is not None:
             args["caption"] = caption
 
-        files = {"video": open(path, "rb")}
+        if path is not None:
+            files = {"video": open(path, "rb")}
+        elif idtg is not None:
+            files = None
+            args["video"] = idtg
 
         return self._api.call("sendVideo", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path, reply_to=None, extra=None,
-                  attach=None, notify=True, caption=None):
+    def send_file(self, path=None, idtg=None, reply_to=None, extra=None, attach=None,
+                  notify=True, caption=None):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
             args["caption"] = caption
 
-        files = {"document": open(path, "rb")}
+        if path is not None:
+            files = {"document": open(path, "rb")}
+        elif idtg is not None:
+            files = None
+            args["document"] = idtg
 
         return self._api.call("sendDocument", args, files,
                               expect=_objects().Message)

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -96,16 +96,19 @@ class ChatMixin:
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
             args["caption"] = caption
-        if path is not None:
+            
+        if path is not None and file_id is None and url is None:
             files = {"photo": open(path, "rb")}
-        elif file_id is not None:
+        elif file_id is not None and path is None and url is None:
             args["photo"] = file_id
             files = None
-        elif url is not None:
+        elif url is not None and file_id is None and path is None:
             args["photo"] = url
             files = None
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
+        else:
+            raise TypeError("Only one among path, file_id and URL must be passed")
 
         return self._api.call("sendPhoto", args, files,
                               expect=_objects().Message)
@@ -125,16 +128,18 @@ class ChatMixin:
         if title is not None:
             args["title"] = title
 
-        if path is not None:
+        if path is not None and file_id is None and url is None:
             files = {"audio": open(path, "rb")}
-        elif file_id is not None:
+        elif file_id is not None and path is None and url is None:
             files = None
             args["audio"] = file_id
-        elif url is not None:
+        elif url is not None and file_id is None and path is None:
             args["audio"] = url
             files = None
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
+        else:
+            raise TypeError("Only one among path, file_id and URL must be passed")
 
         return self._api.call("sendAudio", args, files,
                               expect=_objects().Message)
@@ -150,16 +155,18 @@ class ChatMixin:
         if duration is not None:
             args["duration"] = duration
 
-        if path is not None:
+        if path is not None and file_id is None and url is None:
             files = {"voice": open(path, "rb")}
-        elif file_id is not None:
+        elif file_id is not None and path is None and url is None:
             files = None
             args["voice"] = file_id
-        elif url is not None:
+        elif url is not None and file_id is None and path is None:
             args["voice"] = url
             files = None
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
+        else:
+            raise TypeError("Only one among path, file_id and URL must be passed")
 
         return self._api.call("sendVoice", args, files,
                               expect=_objects().Message)
@@ -175,16 +182,18 @@ class ChatMixin:
         if caption is not None:
             args["caption"] = caption
 
-        if path is not None:
+        if path is not None and file_id is None and url is None:
             files = {"video": open(path, "rb")}
-        elif file_id is not None:
+        elif file_id is not None and path is None and url is None:
             files = None
             args["video"] = file_id
-        elif url is not None:
+        elif url is not None and file_id is None and path is None:
             args["video"] = url
             files = None
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
+        else:
+            raise TypeError("Only one among path, file_id and URL must be passed")
 
         return self._api.call("sendVideo", args, files,
                               expect=_objects().Message)
@@ -197,16 +206,18 @@ class ChatMixin:
         if caption is not None:
             args["caption"] = caption
 
-        if path is not None:
+        if path is not None and file_id is None and url is None:
             files = {"document": open(path, "rb")}
-        elif file_id is not None:
+        elif file_id is not None and path is None and url is None:
             files = None
             args["document"] = file_id
-        elif url is not None:
+        elif url is not None and file_id is None and path is None:
             args["document"] = url
             files = None
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
+        else:
+            raise TypeError("Only one among path, file_id and URL must be passed")
 
         return self._api.call("sendDocument", args, files,
                               expect=_objects().Message)

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -104,7 +104,7 @@ class ChatMixin:
         elif url is not None:
             args["photo"] = url
             files = None
-        elif path is None and file_id is None and url is not None:
+        elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendPhoto", args, files,
@@ -133,7 +133,7 @@ class ChatMixin:
         elif url is not None:
             args["audio"] = url
             files = None
-        elif path is None and file_id is None and url is not None:
+        elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendAudio", args, files,
@@ -158,7 +158,7 @@ class ChatMixin:
         elif url is not None:
             args["voice"] = url
             files = None
-        elif path is None and file_id is None and url is not None:
+        elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendVoice", args, files,
@@ -183,7 +183,7 @@ class ChatMixin:
         elif url is not None:
             args["video"] = url
             files = None
-        elif path is None and file_id is None and url is not None:
+        elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendVideo", args, files,
@@ -205,7 +205,7 @@ class ChatMixin:
         elif url is not None:
             args["document"] = url
             files = None
-        elif path is None and file_id is None and url is not None:
+        elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendDocument", args, files,

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -105,14 +105,14 @@ class ChatMixin:
             args["photo"] = url
             files = None
         elif path is None and file_id is None and url is None:
-            raise TypeError("path or file_id or URL is  missing")
+            raise TypeError("path or file_id or URL is missing")
 
         return self._api.call("sendPhoto", args, files,
                               expect=_objects().Message)
 
     @_require_api
     def send_audio(self, path=None, file_id=None, url=None, duration=None,
-                   title=None, performer=None, abstitle=None, reply_to=None,
+                   performer=None, title=None, reply_to=None,
                    extra=None, attach=None, notify=True, caption=None):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
@@ -134,13 +134,13 @@ class ChatMixin:
             args["audio"] = url
             files = None
         elif path is None and file_id is None and url is None:
-            raise TypeError("path or file_id or URL is  missing")
+            raise TypeError("path or file_id or URL is missing")
 
         return self._api.call("sendAudio", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path=None, url=None, file_id=None, duration=None,
+    def send_voice(self, path=None, file_id=None, url=None, duration=None,
                    title=None, reply_to=None, extra=None, attach=None,
                    notify=True, caption=None):
         """Send a voice message"""
@@ -159,7 +159,7 @@ class ChatMixin:
             args["voice"] = url
             files = None
         elif path is None and file_id is None and url is None:
-            raise TypeError("path or file_id or URL is  missing")
+            raise TypeError("path or file_id or URL is missing")
 
         return self._api.call("sendVoice", args, files,
                               expect=_objects().Message)
@@ -184,7 +184,7 @@ class ChatMixin:
             args["video"] = url
             files = None
         elif path is None and file_id is None and url is None:
-            raise TypeError("path or file_id or URL is  missing")
+            raise TypeError("path or file_id or URL is missing")
 
         return self._api.call("sendVideo", args, files,
                               expect=_objects().Message)
@@ -206,7 +206,7 @@ class ChatMixin:
             args["document"] = url
             files = None
         elif path is None and file_id is None and url is None:
-            raise TypeError("path or file_id or URL is  missing")
+            raise TypeError("path or file_id or URL is missing")
 
         return self._api.call("sendDocument", args, files,
                               expect=_objects().Message)

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -96,7 +96,7 @@ class ChatMixin:
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
             args["caption"] = caption
-        
+
         if path is not None and file_id is None and url is None:
             files = {"photo": open(path, "rb")}
         elif file_id is not None and path is None and url is None:
@@ -108,7 +108,8 @@ class ChatMixin:
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
         else:
-            raise TypeError("Only one among path, file_id and URL must be passed")
+            raise TypeError("Only one among path, file_id and URL must be" +
+                            "passed")
 
         return self._api.call("sendPhoto", args, files,
                               expect=_objects().Message)
@@ -139,7 +140,8 @@ class ChatMixin:
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
         else:
-            raise TypeError("Only one among path, file_id and URL must be passed")
+            raise TypeError("Only one among path, file_id and URL must be" +
+                            "passed")
 
         return self._api.call("sendAudio", args, files,
                               expect=_objects().Message)
@@ -148,7 +150,6 @@ class ChatMixin:
     def send_voice(self, path=None, file_id=None, url=None, duration=None,
                    title=None, reply_to=None, extra=None, attach=None,
                    notify=True, caption=None):
-
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -167,7 +168,8 @@ class ChatMixin:
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
         else:
-            raise TypeError("Only one among path, file_id and URL must be passed")
+            raise TypeError("Only one among path, file_id and URL must be" +
+                            "passed")
 
         return self._api.call("sendVoice", args, files,
                               expect=_objects().Message)
@@ -194,7 +196,8 @@ class ChatMixin:
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
         else:
-            raise TypeError("Only one among path, file_id and URL must be passed")
+            raise TypeError("Only one among path, file_id and URL must be" +
+                            "passed")
 
         return self._api.call("sendVideo", args, files,
                               expect=_objects().Message)
@@ -218,7 +221,8 @@ class ChatMixin:
         elif path is None and file_id is None and url is None:
             raise TypeError("path or file_id or URL is missing")
         else:
-            raise TypeError("Only one among path, file_id and URL must be passed")
+            raise TypeError("Only one among path, file_id and URL must be" +
+                            "passed")
 
         return self._api.call("sendDocument", args, files,
                               expect=_objects().Message)

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -90,27 +90,29 @@ class ChatMixin:
         return self._api.call("sendMessage", args, expect=_objects().Message)
 
     @_require_api
-    def send_photo(self, path=None, idtg=None, caption=None, reply_to=None, extra=None,
-                   attach=None, notify=True):
+    def send_photo(self, path=None, file_id=None, url=None, caption=None,
+                   reply_to=None, extra=None, attach=None, notify=True):
         """Send a photo"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
             args["caption"] = caption
         if path is not None:
             files = {"photo": open(path, "rb")}
-        elif idtg is not None:
-            args["photo"] = idtg
+        elif file_id is not None:
+            args["photo"] = file_id
             files = None
+        elif url is not None:
+            args["photo"] = url
+            files = None
+        elif path is None and file_id is None and url is not None:
+            raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendPhoto", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_audio(self, path, duration=None, performer=None,
-                   title=None, reply_to=None, extra=None, attach=None,
-                   notify=True, caption=None):
-    def send_audio(self, path=None, file_id=None, duration=None,
-                   performer=None, title=None, reply_to=None,
+    def send_audio(self, path=None, file_id=None, url=None, duration=None,
+                   title=None, performer=None, abstitle=None, reply_to=None,
                    extra=None, attach=None, notify=True, caption=None):
         """Send an audio track"""
         args = self._get_call_args(reply_to, extra, attach, notify)
@@ -125,16 +127,22 @@ class ChatMixin:
 
         if path is not None:
             files = {"audio": open(path, "rb")}
-        elif idtg is not None:
+        elif file_id is not None:
             files = None
-            args["audio"] = idtg
+            args["audio"] = file_id
+        elif url is not None:
+            args["audio"] = url
+            files = None
+        elif path is None and file_id is None and url is not None:
+            raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendAudio", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_voice(self, path=None, idtg=None, duration=None, title=None, reply_to=None,
-                   extra=None, attach=None, notify=True, caption=None):
+    def send_voice(self, path=None, url=None, file_id=None, duration=None,
+                   title=None, reply_to=None, extra=None, attach=None,
+                   notify=True, caption=None):
         """Send a voice message"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -144,16 +152,22 @@ class ChatMixin:
 
         if path is not None:
             files = {"voice": open(path, "rb")}
-        elif idtg is not None:
+        elif file_id is not None:
             files = None
-            args["voice"] = idtg
+            args["voice"] = file_id
+        elif url is not None:
+            args["voice"] = url
+            files = None
+        elif path is None and file_id is None and url is not None:
+            raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendVoice", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_video(self, path=None, idtg=None, duration=None, caption=None, reply_to=None,
-                   extra=None, attach=None, notify=True):
+    def send_video(self, path=None, file_id=None, url=None,
+                   duration=None, caption=None, reply_to=None, extra=None,
+                   attach=None, notify=True):
         """Send a video"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if duration is not None:
@@ -163,16 +177,21 @@ class ChatMixin:
 
         if path is not None:
             files = {"video": open(path, "rb")}
-        elif idtg is not None:
+        elif file_id is not None:
             files = None
-            args["video"] = idtg
+            args["video"] = file_id
+        elif url is not None:
+            args["video"] = url
+            files = None
+        elif path is None and file_id is None and url is not None:
+            raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendVideo", args, files,
                               expect=_objects().Message)
 
     @_require_api
-    def send_file(self, path=None, idtg=None, reply_to=None, extra=None, attach=None,
-                  notify=True, caption=None):
+    def send_file(self, path=None, file_id=None, url=None, reply_to=None,
+                  extra=None, attach=None, notify=True, caption=None):
         """Send a generic file"""
         args = self._get_call_args(reply_to, extra, attach, notify)
         if caption is not None:
@@ -180,9 +199,14 @@ class ChatMixin:
 
         if path is not None:
             files = {"document": open(path, "rb")}
-        elif idtg is not None:
+        elif file_id is not None:
             files = None
-            args["document"] = idtg
+            args["document"] = file_id
+        elif url is not None:
+            args["document"] = url
+            files = None
+        elif path is None and file_id is None and url is not None:
+            raise TypeError("path or file_id or URL is  missing")
 
         return self._api.call("sendDocument", args, files,
                               expect=_objects().Message)

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -125,11 +125,14 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_photo(path, [caption=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_photo([path=None, file_id=None, url=None, caption=None, reply_to=None, extra=None, attach=None, notify=True])
 
-      Send a photo found at *path* to the user. You may optionally specify a
-      *caption* for the photo being sent. If the photo you are sending is in
-      reply to another message, set *reply_to* to the ID of the other
+      Send a photo to the user. You can specify the photo by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify a *caption* for the photo being sent.
+      If the photo you are sending is in reply to another message,
+      set *reply_to* to the ID of the other
       :py:class:`~botogram.Message`.
 
       The *attach* parameter allows you to attach extra things like
@@ -139,6 +142,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the photo.
+      :param str file_id: The Telegram *file_id* of the photo.
+      :param str url: The URL to the photo.
       :param str caption: A caption for the photo.
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to.
       :param object attach: An extra thing to attach to the message.
@@ -154,12 +159,18 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+         
+      .. versionchanged:: 0.5
 
-   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+         Added support for *file_id* and *url*.
 
-      Send the audio track found in the *path* to the user. You may optionally
-      specify the *duration*, the *performer* and the *title* of the audio
-      track. If the audio track you're sending is in reply to another message,
+   .. py:method:: send_audio([path=None, file_id=None, url=None, duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+
+      Send an audio track to the user. You can specify the track by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify the *duration*, the *performer* and the *title* 
+      of the audio track. If the audio track you're sending is in reply to another message,
       set *reply_to* to the ID of the other :py:class:`~botogram.Message`.
 
       The *attach* parameter allows you to attach extra things like
@@ -169,6 +180,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the audio track
+      :param str file_id: The Telegram *file_id* of the audio track
+      :param str url: The URL to the audio track
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -190,12 +203,14 @@ about its business.
          
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*.
 
-   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+   .. py:method:: send_voice([path=None, file_id=None, url=None, duration=None, reply_to=None,  extra=None, attach=None, notify=True, caption=None])
 
-      Send the voice message found in the *path* to the user. You may
-      optionally specify the *duration* of the voice message. If the voice
+      Send a voice message to the user. You can specify the audio by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify the *duration* of the voice message. If the voice
       message you're sending is in reply to another message, set *reply_to* to
       the ID of the other :py:class:`~botogram.Message`.
 
@@ -206,6 +221,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the voice message
+      :param str file_id: The Telegram *file_id* of the voice message
+      :param str url: The URL to the audio
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
@@ -225,14 +242,16 @@ about its business.
          
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*.
 
-   .. py:method:: send_video(path, [duration=None, caption=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_video([path=None, file_id=None, url=None, duration=None, caption=None, reply_to=None, attach=None, extra=None, notify=True])
 
-      Send the video found in the *path* to the user. You may optionally
-      specify the *duration* and the *caption* of the video. If the audio track
-      you're sending is in reply to another message, set *reply_to* to the ID
-      of the other :py:class:`~botogram.Message`.
+      Send a video to the user. You can specify the video by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify the *duration* and the *caption* of the video.
+      If the audio track you're sending is in reply to another message, 
+      set *reply_to* to the ID of the other :py:class:`~botogram.Message`.
 
       The *attach* parameter allows you to attach extra things like
       :ref:`buttons <buttons>` to the message.
@@ -241,6 +260,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the video
+      :param str file_id: The Telegram *file_id* of the video
+      :param str url: The URL to the video
       :param int duration: The video duration, in seconds
       :param str caption: The caption of the video
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
@@ -257,11 +278,17 @@ about its business.
       .. versionchanged:: 0.3
 
          Now the method returns the sent message
+         
+       .. versionchanged:: 0.5
 
-   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True, caption=None])
+         Added support for *file_id* and *url*.
 
-      Send the generic file found in the *path* to the user. If the file you're
-      sending is in reply to another message, set *reply_to* to the ID of the
+   .. py:method:: send_file([path=None, file_id=None, url=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+
+      Send a generic file to the user. You can specify the file by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      If the file you're sending is in reply to another message, set *reply_to* to the ID of the
       other :py:class:`~botogram.Message`.
 
       The *attach* parameter allows you to attach extra things like
@@ -271,6 +298,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the file
+      :param str file_id: The Telegram *file_id* of the video
+      :param str url: The URL to the video
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
@@ -289,7 +318,7 @@ about its business.
          
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*.
 
    .. py:method:: send_location(latitude, longitude, [reply_to=None, attach=None, extra=None, notify=True])
 
@@ -713,9 +742,12 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_photo(path, [caption=None, reply_to=None, attach=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_photo([path=None, file_id=None, url=None, caption=None, reply_to=None, attach=None, extra=None, attach=None, notify=True])
 
-      Send a photo found at *path* to the chat. You may optionally specify a
+      Send a photo to the chat. You can specify the photo by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify a
       *caption* for the photo being sent. If the photo you are sending is in
       reply to another message, set *reply_to* to the ID of the other
       :py:class:`~botogram.Message`.
@@ -727,6 +759,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the photo.
+      :param str file_id: The Telegram *file_id* of the photo.
+      :param str url: The URL to the photo.
       :param str caption: A caption for the photo.
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to.
       :param object attach: An extra thing to attach to the message.
@@ -743,9 +777,16 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_audio(path, [duration=None, performer=None, title=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+      .. versionchanged:: 0.5
 
-      Send the audio track found in the *path* to the chat. You may optionally
+         Added support for *file_id* and *url*
+
+   .. py:method:: send_audio([path=None, file_id=None, url=None, duration=None, performer=None, title=None, reply_to=None, extra=None, attach=None, notify=True, caption=None])
+
+      Send an audio track to the chat. You can specify the track by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally
       specify the *duration*, the *performer* and the *title* of the audio
       track. If the audio track you're sending is in reply to another message,
       set *reply_to* to the ID of the other :py:class:`~botogram.Message`.
@@ -757,6 +798,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the audio track
+      :param str file_id: The Telegram *file_id* of the track
+      :param str url: The URL to the track
       :param int duration: The track duration, in seconds
       :param str performer: The name of the performer
       :param str title: The title of the track
@@ -778,12 +821,14 @@ about its business.
 
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*
 
-   .. py:method:: send_voice(chat, path, [duration=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+   .. py:method:: send_voice([path=None, file_id=None, url=None, duration=None, reply_to=None, extra=None, attach=None, notify=True, caption=None])
 
-      Send the voice message found in the *path* to the chat. You may
-      optionally specify the *duration* of the voice message. If the voice
+      Send a voice message to the chat. You can specify the audio by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally specify the *duration* of the voice message. If the voice
       message you're sending is in reply to another message, set *reply_to* to
       the ID of the other :py:class:`~botogram.Message`.
 
@@ -794,6 +839,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the voice message
+      :param str file_id: The Telegram *file_id* of the audio
+      :param str url: The URL to the audio
       :param int duration: The message duration, in seconds
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
@@ -813,11 +860,14 @@ about its business.
 
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*
 
-   .. py:method:: send_video(path, [duration=None, caption=None, reply_to=None, attach=None, extra=None, notify=True])
+   .. py:method:: send_video([path=None, file_id=None, url=None, duration=None, caption=None, reply_to=None, extra=None, attach=None, notify=True])
 
-      Send the video found in the *path* to the chat. You may optionally
+      Send a video to the chat. You can specify the video by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      You may optionally
       specify the *duration* and the *caption* of the video. If the audio track
       you're sending is in reply to another message, set *reply_to* to the ID
       of the other :py:class:`~botogram.Message`.
@@ -829,6 +879,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the video
+      :param str file_id: The Telegram *file_id* of the video
+      :param str url: The URL to the video
       :param int duration: The video duration, in seconds
       :param str caption: The caption of the video
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
@@ -846,10 +898,16 @@ about its business.
 
          Now the method returns the sent message
 
-   .. py:method:: send_file(path, [reply_to=None, attach=None, extra=None, notify=True, caption=None])
+      .. versionchanged:: 0.5
 
-      Send the generic file found in the *path* to the chat. If the file you're
-      sending is in reply to another message, set *reply_to* to the ID of the
+         Added support for *file_id* and *url*
+
+   .. py:method:: send_file([path=None, file_id=None, url=None, reply_to=None, attach=None, extra=None, notify=True, caption=None])
+
+      Send a generic file to the chat. You can specify the video by passing its *path*,
+      its *url*, or its Telegram *file_id*. Only one of these arguments must be passed.
+      
+      If the file you're sending is in reply to another message, set *reply_to* to the ID of the
       other :py:class:`~botogram.Message`.
 
       The *attach* parameter allows you to attach extra things like
@@ -859,6 +917,8 @@ about its business.
       a notification on the client side (yes by default).
 
       :param str path: The path to the file
+      :param str file_id: The Telegram *file_id* of the file
+      :param str url: The URL to the file
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
       :param object attach: An extra thing to attach to the message.
       :param object extra: An extra reply interface object to attach
@@ -877,7 +937,7 @@ about its business.
 
       .. versionchanged:: 0.5
 
-         Added support for caption
+         Added support for *caption*, *file_id* and *url*
 
    .. py:method:: send_location(latitude, longitude, [reply_to=None, attach=None, extra=None, notify=True])
 


### PR DESCRIPTION
This is implemented adding two new optional arguments to the methods to send files, which are called `file_id` and `url`.

Another way to do that would be making `path` accept also `file_id`s and URLs (possibly changing the name of the variable to `document`) and adding another (non optional) string argument which should always be `"file_id"`, `"url"`, or `"path"` and tells botogram how to interpret the document string. If needed I'm willing to code it, or accept any contribution to this branch.